### PR TITLE
Add Promise_io to Kxclib_melange

### DIFF
--- a/melange/dune
+++ b/melange/dune
@@ -54,7 +54,7 @@
  (target _output)
  (modules)
  (promote (until-clean))
- (libraries kxclib_melange))
+ (libraries kxclib_melange kxclib_melange_test))
 
 (rule
  (alias init)
@@ -67,10 +67,14 @@
  (deps
   (sandbox none)
   node_modules
-  (alias melange)
-  (source_tree tests))
+  (source_tree src)
+  (source_tree tests)
+  (:outputs
+    _output/node_modules/kxclib.melange/kxclib_melange.js
+    _output/melange/tests/kxclib_melange_test.js))
  (action
-  (with-accepted-exit-codes 0
-   (run yarn test))))
+   (progn
+    (run yarn prepare-packages)
+    (with-accepted-exit-codes 0 (run yarn test)))))
 
 (dirs :standard \ node_modules)

--- a/melange/dune
+++ b/melange/dune
@@ -1,6 +1,10 @@
 (rule
  (target kxclib_melange.ml)
- (deps kxclib.pp.ml src/kxclib_comp_mel.ml src/kxclib_melange_extra.ml)
+ (deps
+  kxclib.pp.ml
+  src/kxclib_comp_mel.ml
+  src/kxclib_melange_extra.ml
+  src/kxclib_promise_io.ml)
  (action
   (with-stdout-to %{target}
    (progn
@@ -10,6 +14,8 @@
     (cat kxclib.pp.ml)
     (echo "\n\n")
     (cat src/kxclib_melange_extra.ml)
+    (echo "\n\n")
+    (cat src/kxclib_promise_io.ml)
     (echo "\n\n")
     (echo "\nmodule Promise = Promise\n")))))
 

--- a/melange/package.json
+++ b/melange/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "license": "MIT",
   "scripts": {
-    "test": "npx jest"
+    "test": "npx jest",
+    "prepare-packages": "cp -r _output/node_modules/* ./node_modules/"
   },
   "files": [
     "*.ml",

--- a/melange/src/kxclib_promise_io.ml
+++ b/melange/src/kxclib_promise_io.ml
@@ -1,0 +1,27 @@
+module PromiseIo : sig
+  include Io_style with type 'a t = 'a Promise.t
+end = struct
+  type 'x t = 'x Promise.t
+
+  let return x : _ t = Promise.resolve x
+
+  let bind : 'x t -> ('x -> 'y t) -> 'y t = fun m af -> Js_promise.then_ af m
+
+  let inject_error (e: exn) : _ t = Js_promise.reject e
+
+  let inject_error' ((e, _): exn * backtrace_info option): 'x t =
+    Js_promise.reject e
+
+  let extract_error : 'x t -> ('x, exn * backtrace_info option) result t =
+    fun m ->
+    let m = bind m (fun x -> Result.ok x |> return) in
+    Promise.catch m (fun exn ->
+      let stack = Js_exn.asJsExn exn >>? Js_exn.stack in
+      let bt : backtrace_info option =
+        match stack with
+        | Some stack -> `string_stacktrace stack |> some
+        | None -> none in
+      Result.error (exn, bt) |> return)
+
+  let trace (s: string) = Js.Console.log(s); return ()
+end

--- a/melange/src/kxclib_promise_io.ml
+++ b/melange/src/kxclib_promise_io.ml
@@ -1,4 +1,4 @@
-module PromiseIo : sig
+module Promise_io : sig
   include Io_style with type 'a t = 'a Promise.t
 end = struct
   type 'x t = 'x Promise.t

--- a/melange/tests/dune
+++ b/melange/tests/dune
@@ -1,0 +1,7 @@
+(library
+ (name kxclib_melange_test)
+ (modules kxclib_melange_test)
+ (libraries kxclib_melange)
+ (modes melange)
+ (preprocess
+  (pps melange.ppx)))

--- a/melange/tests/kxclib.spec.js
+++ b/melange/tests/kxclib.spec.js
@@ -4,7 +4,7 @@ const kxclib_melange_test = require('../_output/melange/tests/kxclib_melange_tes
 const JsonExt = kxclib.Json_ext;
 
 const Json_ext_test = kxclib_melange_test.Json_ext_test;
-const PromiseIo_test = kxclib_melange_test.PromiseIo_test;
+const Promise_io_test = kxclib_melange_test.Promise_io_test;
 
 test('it loads', () => {
   expect(kxclib).toBeDefined();
@@ -12,7 +12,7 @@ test('it loads', () => {
   
   expect(kxclib_melange_test).toBeDefined();
   expect(Json_ext_test).toBeDefined();
-  expect(PromiseIo_test).toBeDefined();
+  expect(Promise_io_test).toBeDefined();
 });
 
 const samples = [
@@ -95,8 +95,8 @@ test('successes of Json_ext.of_json_string_opt & Json_ext.to_json_string (ported
   Json_ext_test.test_string_success();
 });
 
-test('PromiseIo (ported)', async () => {
-  for (const test of PromiseIo_test.tests) {
+test('Promise_io (ported)', async () => {
+  for (const test of Promise_io_test.tests) {
     await test();
   }
 });

--- a/melange/tests/kxclib.spec.js
+++ b/melange/tests/kxclib.spec.js
@@ -1,10 +1,18 @@
 const kxclib = require('../_output/node_modules/kxclib.melange/kxclib_melange');
+const kxclib_melange_test = require('../_output/melange/tests/kxclib_melange_test');
 
 const JsonExt = kxclib.Json_ext;
+
+const Json_ext_test = kxclib_melange_test.Json_ext_test;
+const PromiseIo_test = kxclib_melange_test.PromiseIo_test;
 
 test('it loads', () => {
   expect(kxclib).toBeDefined();
   expect(JsonExt).toBeDefined();
+  
+  expect(kxclib_melange_test).toBeDefined();
+  expect(Json_ext_test).toBeDefined();
+  expect(PromiseIo_test).toBeDefined();
 });
 
 const samples = [
@@ -56,10 +64,18 @@ test('Json_ext with samples', () => {
   }
 });
 
+test('Json_ext with samples (ported', () => {
+  Json_ext_test.test_with_samples();
+});
+
 test('failure of Json_ext.of_json_string_opt', () => {
   expect(JsonExt.of_json_string_opt('{')).toBeUndefined();
   expect(JsonExt.of_json_string_opt('{age: 12}')).toBeUndefined(); // violating JSON spec as field name not properly quoted
   expect(JsonExt.of_json_string_opt("{'age': 12}")).toBeUndefined(); // violating JSON spec as field name not properly quoted
+});
+
+test('failure of Json_ext.of_json_string_opt (ported)', () => {
+  Json_ext_test.test_of_json_string_opt_failure();
 });
 
 test('successes of Json_ext.of_json_string_opt & Json_ext.to_json_string', () => {
@@ -72,5 +88,15 @@ test('successes of Json_ext.of_json_string_opt & Json_ext.to_json_string', () =>
     const json2 = JsonExt.to_json_string(jv);
     const parsed2 = JSON.parse(json2);
     expect(parsed2).toStrictEqual(normalizedValue || value);
+  }
+});
+
+test('successes of Json_ext.of_json_string_opt & Json_ext.to_json_string (ported)', () => {
+  Json_ext_test.test_string_success();
+});
+
+test('PromiseIo (ported)', async () => {
+  for (const test of PromiseIo_test.tests) {
+    await test();
   }
 });

--- a/melange/tests/kxclib_melange_test.ml
+++ b/melange/tests/kxclib_melange_test.ml
@@ -104,10 +104,24 @@ end = struct
       | Error (exn, _backtrace) ->
         to_strict_equal (expect exn) error;
         return ()
+        
+  let test03 () =
+    let module M = MonadOps(PromiseIo) in
+    let open M in
+    return ()
+    
+  let test04 () =
+    let module M = MonadOps(PromiseIo) in
+    let open M in
+    return 40 >>= fun x ->
+      to_be (expect (x + 2)) 42;
+      return ()
 
   let tests = [|
     PromiseIo.return;
     test01;
-    test02
+    test02;
+    test03;
+    test04;
   |]
 end

--- a/melange/tests/kxclib_melange_test.ml
+++ b/melange/tests/kxclib_melange_test.ml
@@ -1,0 +1,113 @@
+open Kxclib_melange
+
+open struct
+  external _cast : 'a -> 'b = "%identity"
+end
+
+module Jest = struct
+  type t
+  external expect : 'a -> t = "expect" [@@bs.val]
+  external to_be : t -> 'a -> unit = "toBe" [@@bs.send]
+  external to_strict_equal : t -> 'a -> unit = "toStrictEqual" [@@bs.send]
+  external to_be_undefined : t -> unit = "toBeUndefined" [@@bs.send]
+end
+
+open Jest
+
+module Json_ext_test : sig
+  val test_with_samples : unit -> unit
+  val test_of_json_string_opt_failure : unit -> unit
+  val test_string_success : unit -> unit
+end = struct
+  type test_sample = {
+    jv: Json.jv;
+    json: Js.Json.t; }
+  
+  let samples: test_sample array = [|
+    { jv = `null;
+      json = [%bs.raw {| null |}] };
+    { jv = `bool true;
+      json = [%bs.raw {| true |}] };
+    { jv = `bool false;
+      json = [%bs.raw {| false |}] };
+    { jv = `num 131.;
+      json = [%bs.raw {| 131 |}] };
+    { jv = `num 131.338;
+      json = [%bs.raw {| 131.338 |}] };
+    { jv = `str "hello?";
+      json = [%bs.raw {| "hello?" |}] };
+    { jv = `str "\x58";
+      json = [%bs.raw {| "\x58" |}] };
+    { jv = `str "日本語";
+      json = Js.Json.string "日本語" };
+    { jv = `arr [];
+      json = [%bs.raw {| [] |}] };
+    { jv = `obj [ "", `obj [] ];
+      json = [%bs.raw {| {"": {}} |}] };
+    { jv = `arr [ `arr [] ];
+      json = [%bs.raw {| [ [] ] |}] };
+    { jv = `arr [ `num 1.; `str "(a number)" ];
+      json = [%bs.raw {| [ 1, "(a number)" ] |}] };
+    { jv = `obj [ "best", `arr []; "friend", `num 23. ];
+      json = [%bs.raw {| { best: [], friend: 23 } |}] };
+    { jv = `arr [ `bool true; `str "hello?" ];
+      json = [%bs.raw {| [ true, "hello?" ] |}] }
+  |]
+  
+  let test_with_samples () =
+    samples |> Array.iter (fun { jv; json } ->
+      let xjv = Json_ext.to_xjv jv in
+      to_strict_equal (expect xjv) json;
+      
+      let jv_of_xjv = Json_ext.of_xjv xjv in
+      to_strict_equal (expect jv_of_xjv) jv;
+      
+      let str = Json_ext.to_json_string(jv) in
+      let jv_of_str = Json_ext.of_json_string_opt str in
+      to_strict_equal (expect jv_of_str) jv
+    )
+    
+  let test_of_json_string_opt_failure () =
+    Json_ext.of_json_string_opt "{" |> expect |> to_be_undefined;
+    
+    (* violating JSON spec as field name not properly quoted *)
+    Json_ext.of_json_string_opt "{age: 12}" |> expect |> to_be_undefined;
+    
+    (* violating JSON spec as field name not properly quoted *)
+    Json_ext.of_json_string_opt "{'age': 12}" |> expect |> to_be_undefined
+    
+  let test_string_success () =
+    samples |> Array.iter (fun { jv; json } ->
+      let parsed01 = json |> Js.Json.stringify |> Json_ext.of_json_string_opt |> Option.get in
+      to_strict_equal (expect (Json_ext.to_xjv parsed01)) json;
+      
+      let parsed02 = jv |> Json_ext.to_json_string |> Js.Json.parseExn in
+      to_strict_equal (expect parsed02) json
+    )
+end
+
+module PromiseIo_test : sig
+  val tests : (unit -> unit PromiseIo.t) array
+end = struct
+  let test01 () =
+    PromiseIo.(bind (return 1) @@ fun x ->
+      to_be (expect (x + 1)) 2;
+      return ())
+
+  let test02 () =
+    let open PromiseIo in
+    let error = Failure "error test" in
+    inject_error error
+    |> extract_error
+    |> Fn.flip bind @@ function
+      | Ok () -> failwith "unexpected"
+      | Error (exn, _backtrace) ->
+        to_strict_equal (expect exn) error;
+        return ()
+
+  let tests = [|
+    PromiseIo.return;
+    test01;
+    test02
+  |]
+end

--- a/melange/tests/kxclib_melange_test.ml
+++ b/melange/tests/kxclib_melange_test.ml
@@ -86,16 +86,16 @@ end = struct
     )
 end
 
-module PromiseIo_test : sig
-  val tests : (unit -> unit PromiseIo.t) array
+module Promise_io_test : sig
+  val tests : (unit -> unit Promise_io.t) array
 end = struct
   let test01 () =
-    PromiseIo.(bind (return 1) @@ fun x ->
+    Promise_io.(bind (return 1) @@ fun x ->
       to_be (expect (x + 1)) 2;
       return ())
 
   let test02 () =
-    let open PromiseIo in
+    let open Promise_io in
     let error = Failure "error test" in
     inject_error error
     |> extract_error
@@ -106,19 +106,19 @@ end = struct
         return ()
         
   let test03 () =
-    let module M = MonadOps(PromiseIo) in
+    let module M = MonadOps(Promise_io) in
     let open M in
     return ()
     
   let test04 () =
-    let module M = MonadOps(PromiseIo) in
+    let module M = MonadOps(Promise_io) in
     let open M in
     return 40 >>= fun x ->
       to_be (expect (x + 2)) 42;
       return ()
 
   let tests = [|
-    PromiseIo.return;
+    Promise_io.return;
     test01;
     test02;
     test03;


### PR DESCRIPTION
`Promise_io` モジュールを追加した。

また、 `Promise_io` のテスト記述をOCamlで書く必要が生じたのに伴って、`Json_ext` のテストもOCamlで書いて追加している。

- fix #45
- fix a part of https://github.com/AnchorZ-org/dzmono/issues/2716


## [resolved] Melange の bug を踏んだ。’

### details
`open MonadOps(PromiseIo)` でうまく動かない。

```ocaml
let test03 () =
    let open MonadOps(PromiseIo) in
    return ()
```

```js
function test03(param) {
  var open = Kxclib_melange.MonadOps(Kxclib_melange.PromiseIo);
  return Curry._1(open[0], undefined);
}
```

```sh
  ● PromiseIo (ported)

    TypeError: Cannot read properties of undefined (reading 'length')

      221 | function test03(param) {
      222 |   var open = Kxclib_melange.MonadOps(Kxclib_melange.PromiseIo);
    > 223 |   return Curry._1(open[0], undefined);
          |                ^
      224 | }
      225 |
      226 | var tests = [

      at Object._1 (_output/node_modules/melange.runtime/curry.js:31:17)
      at _1 (_output/melange/tests/kxclib_melange_test.js:223:16)
      at Object.test (tests/kxclib.spec.js:100:11)
```

### resolved

```ocaml
  let test03 () =
    let module M = MonadOps(PromiseIo) in
    let open M in
    return ()
```

```js
function test03(param) {
  var M = Kxclib_melange.MonadOps(Kxclib_melange.PromiseIo);
  return Curry._1(M.$$return, undefined);
}
```