### PR TITLE
update OCaml version constraint of Obj.hash_variant (#100)

### DIFF
--- a/classic/kxclib.ml
+++ b/classic/kxclib.ml
@@ -1469,8 +1469,9 @@ end
 module Obj = struct
   include Obj
 
-  [%%if ocaml_version <= (5, 1, 1)]
+  [%%if ocaml_version < (5, 4, 0)]
   (* latest known version of OCaml using this implementation *)
+  (* https://github.com/ocaml/ocaml/blob/5.3/runtime/hash.c#L313-L325 *)
   let hash_variant s =
     let accu = ref 0 in
     for i = 0 to String.length s - 1 do


### PR DESCRIPTION
(redo of #61)