### PR TITLE
revert change of yojson type

### DIFF
--- a/classic/kxclib.ml
+++ b/classic/kxclib.ml
@@ -3003,9 +3003,7 @@ end = struct
     | `Int x -> `num (float_of_int x)
     | `Intlit x -> `num (float_of_string x)
     | `Float x -> `num x
-    | `Floatlit x -> `num (float_of_string x)
     | `String x -> `str x
-    | `Stringlit x -> `str x
     | `Assoc x -> `obj (x |&> ?>of_yojson)
     | `List x -> `arr (x |&> of_yojson)
     | `Tuple x -> `arr (x |&> of_yojson)
@@ -3042,8 +3040,6 @@ end = struct
     | `Int x -> `Int x
     | `Intlit x -> `Int (int_of_string x)
     | `Float x -> `Float x
-    | `Floatlit x -> `Float (float_of_string x)
-    | `Stringlit x -> `String x
     | `String x -> `String x
     | `Assoc xs -> `Assoc (xs |&> fun (n, x) -> (n, yojson_basic_of_safe x))
     | `List xs -> `List (xs |&> yojson_basic_of_safe)

--- a/yojson-compat/yojson_compat.ml
+++ b/yojson-compat/yojson_compat.ml
@@ -14,15 +14,14 @@ type yojson = ([
     | `Variant of string * 't option
     ] as 't)
 [%%else]
-type yojson = ([ `Assoc of (string * 't) list
+type yojson = ([
     | `Null
     | `Bool of bool
     | `Int of int
     | `Intlit of string
     | `Float of float
-    | `Floatlit of string
     | `String of string
-    | `Stringlit of string
+    | `Assoc of (string * 't) list
     | `List of 't list
     ] as 't)
 [%%endif]


### PR DESCRIPTION
https://github.com/kxcinc/bindoj/pull/438/commits/f21c3633a991ac5eb381a7915d74a69ea71e184c のCIがpassしたことがこの修正が正しいことの根拠になるはず。